### PR TITLE
Simple delegate method to detect dismissal

### DIFF
--- a/SmartWKWebView/Classes/SmartWKWebViewController.swift
+++ b/SmartWKWebView/Classes/SmartWKWebViewController.swift
@@ -19,6 +19,7 @@ public class SmartWKWebViewController: PannableViewController, WKNavigationDeleg
     public var stringLoading = "Loading"
     public var url: URL!
     public var webView: WKWebView!
+	var delegate: SmartWKWebViewControllerDelegate?
     var toolbar: SmartWKWebViewToolbar!
     
     
@@ -123,7 +124,9 @@ public class SmartWKWebViewController: PannableViewController, WKNavigationDeleg
     
     private func dismiss() {
         OperationQueue.main.addOperation {
-            self.dismiss(animated: true, completion: nil)
+			self.dismiss(animated: true, completion: {
+				self.delegate?.didDismiss(viewController: self)
+			})
         }
     }
     
@@ -169,4 +172,8 @@ public class SmartWKWebViewController: PannableViewController, WKNavigationDeleg
             webView.scrollView.contentOffset.y = 0
         }
     }
+}
+
+protocol SmartWKWebViewControllerDelegate {
+	func didDismiss(viewController: SmartWKWebViewController)
 }

--- a/SmartWKWebView/Classes/SmartWKWebViewController.swift
+++ b/SmartWKWebView/Classes/SmartWKWebViewController.swift
@@ -125,7 +125,7 @@ public class SmartWKWebViewController: PannableViewController, WKNavigationDeleg
     private func dismiss() {
         OperationQueue.main.addOperation {
 			self.dismiss(animated: true, completion: {
-				self.delegate?.didDismiss(viewController: self)
+				self.delegate?.didDismiss?(viewController: self)
 			})
         }
     }
@@ -174,6 +174,6 @@ public class SmartWKWebViewController: PannableViewController, WKNavigationDeleg
     }
 }
 
-public protocol SmartWKWebViewControllerDelegate {
-	func didDismiss(viewController: SmartWKWebViewController)
+@objc public protocol SmartWKWebViewControllerDelegate {
+	@objc optional func didDismiss(viewController: SmartWKWebViewController)
 }

--- a/SmartWKWebView/Classes/SmartWKWebViewController.swift
+++ b/SmartWKWebView/Classes/SmartWKWebViewController.swift
@@ -19,7 +19,7 @@ public class SmartWKWebViewController: PannableViewController, WKNavigationDeleg
     public var stringLoading = "Loading"
     public var url: URL!
     public var webView: WKWebView!
-	var delegate: SmartWKWebViewControllerDelegate?
+	public var delegate: SmartWKWebViewControllerDelegate?
     var toolbar: SmartWKWebViewToolbar!
     
     
@@ -174,6 +174,6 @@ public class SmartWKWebViewController: PannableViewController, WKNavigationDeleg
     }
 }
 
-protocol SmartWKWebViewControllerDelegate {
+public protocol SmartWKWebViewControllerDelegate {
 	func didDismiss(viewController: SmartWKWebViewController)
 }


### PR DESCRIPTION
I encountered a use case where I needed to detect the dismissal of the SmartWKWebViewController from the presenting UIViewController. It made sense to create a simple SmartWKWebViewControllerDelegate protocol with an optional `didDismiss(viewController:)` method.

It works as expected and I thought others might benefit from this. It also sets the groundwork up for more delegate methods if needs be in the future.